### PR TITLE
Utvider JournalføringsResponse til å inneholde liste med dokumentinfo.

### DIFF
--- a/src/main/kotlin/no/nav/helse/journalforing/JournalPostId.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/JournalPostId.kt
@@ -1,3 +1,0 @@
-package no.nav.helse.journalforing
-
-data class JournalPostId(val value: String)

--- a/src/main/kotlin/no/nav/helse/journalforing/JournalføringsResponse.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/JournalføringsResponse.kt
@@ -1,0 +1,5 @@
+package no.nav.helse.journalforing
+
+import no.nav.helse.journalforing.gateway.DokumentInfo
+
+data class JournalføringsResponse(val journalpostId: String, val dokumenter: List<DokumentInfo>)

--- a/src/main/kotlin/no/nav/helse/journalforing/api/JorunalforingApis.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/api/JorunalforingApis.kt
@@ -12,6 +12,7 @@ import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.post
 import io.ktor.util.pipeline.PipelineContext
+import no.nav.helse.journalforing.gateway.DokumentInfo
 import no.nav.helse.journalforing.v1.JournalforingV1Service
 import no.nav.helse.journalforing.v1.MeldingV1
 import no.nav.helse.journalforing.v1.MetadataV1
@@ -78,8 +79,8 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.journalfør(
     melding: MeldingV1,
     metadata: MetadataV1
 ) {
-    val journalPostId = journalforingV1Service.journalfor(melding = melding, metaData = metadata)
-    call.respond(HttpStatusCode.Created, JournalforingResponse(journalPostId = journalPostId.value))
+    val journalføringsResponse = journalforingV1Service.journalfor(melding = melding, metaData = metadata)
+    call.respond(HttpStatusCode.Created, JournalforingResponse(journalPostId = journalføringsResponse.journalpostId, dokumenter = journalføringsResponse.dokumenter))
 }
 
 private fun ApplicationRequest.getCorrelationId(): String {
@@ -90,4 +91,4 @@ private fun ApplicationResponse.getRequestId(): String? {
     return headers[HttpHeaders.XRequestId]
 }
 
-data class JournalforingResponse(val journalPostId: String)
+data class JournalforingResponse(val journalPostId: String, val dokumenter: List<DokumentInfo>)

--- a/src/main/kotlin/no/nav/helse/journalforing/gateway/JournalPostResponse.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/gateway/JournalPostResponse.kt
@@ -12,5 +12,5 @@ data class JournalPostResponse(
 )
 data class DokumentInfo(
     val dokumentInfoId: String,
-    val tittel: String
+    val tittel: String? = null
 )

--- a/src/main/kotlin/no/nav/helse/journalforing/gateway/JournalPostResponse.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/gateway/JournalPostResponse.kt
@@ -11,5 +11,6 @@ data class JournalPostResponse(
     val dokumenter: List<DokumentInfo>
 )
 data class DokumentInfo(
-    val dokumentInfoId: String
+    val dokumentInfoId: String,
+    val tittel: String
 )

--- a/src/main/kotlin/no/nav/helse/journalforing/v1/JournalforingV1Service.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/v1/JournalforingV1Service.kt
@@ -28,7 +28,7 @@ class JournalforingV1Service(
     suspend fun journalfor(
         melding: MeldingV1,
         metaData: MetadataV1
-    ): JournalPostId {
+    ): JournalføringsResponse {
 
         val correlationId = CorrelationId(metaData.correlationId)
 
@@ -77,7 +77,7 @@ class JournalforingV1Service(
         val response = journalforingGateway.jorunalfor(request)
 
         logger.info("JournalPost med ID ${response.journalpostId} opprettet")
-        return JournalPostId(response.journalpostId)
+        return JournalføringsResponse(response.journalpostId, response.dokumenter)
     }
 
     private fun validerMelding(melding: MeldingV1) {

--- a/src/test/kotlin/no/nav/helse/DokarkivResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/helse/DokarkivResponseTransformer.kt
@@ -43,6 +43,7 @@ internal class DokarkivResponseTransformer : ResponseTransformer() {
 }
 
 private fun getResponse(journalpostId: String) =
+    //language=json
     """       
         {
           "journalpostId": "$journalpostId",
@@ -51,10 +52,12 @@ private fun getResponse(journalpostId: String) =
           "journalpostferdigstilt": false,
           "dokumenter": [
             {
-              "dokumentInfoId": "485201432"
+              "dokumentInfoId": "485201432",
+              "tittel": "Søknad om omsorgspenger - utvidet rett"
             },
             {
-              "dokumentInfoId": "485201433"
+              "dokumentInfoId": "485201433",
+              "tittel": "legeerklæring"
             }
           ]
         }

--- a/src/test/kotlin/no/nav/helse/DokarkivResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/helse/DokarkivResponseTransformer.kt
@@ -57,7 +57,7 @@ private fun getResponse(journalpostId: String) =
             },
             {
               "dokumentInfoId": "485201433",
-              "tittel": "legeerklæring"
+              "tittel": null
             }
           ]
         }

--- a/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
+++ b/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
@@ -123,7 +123,7 @@ class K9JoarkTest {
                     },
                     {
                       "dokument_info_id": "485201433",
-                      "tittel": "legeerklæring"
+                      "tittel": null
                     }
             ]
                 }
@@ -148,7 +148,7 @@ class K9JoarkTest {
                     },
                     {
                       "dokument_info_id": "485201433",
-                      "tittel": "legeerklæring"
+                      "tittel": null
                     }
             ]
                 }
@@ -174,7 +174,7 @@ class K9JoarkTest {
                     },
                     {
                       "dokument_info_id": "485201433",
-                      "tittel": "legeerklæring"
+                      "tittel": null
                     }
           ]
                 }
@@ -200,7 +200,7 @@ class K9JoarkTest {
                     },
                     {
                       "dokument_info_id": "485201433",
-                      "tittel": "legeerklæring"
+                      "tittel": null
                     }
             ]
                 }
@@ -226,7 +226,7 @@ class K9JoarkTest {
                     },
                     {
                       "dokument_info_id": "485201433",
-                      "tittel": "legeerklæring"
+                      "tittel": null
                     }
             ]
                 }
@@ -252,7 +252,7 @@ class K9JoarkTest {
                     },
                     {
                       "dokument_info_id": "485201433",
-                      "tittel": "legeerklæring"
+                      "tittel": null
                     }
             ]
                 }
@@ -278,7 +278,7 @@ class K9JoarkTest {
                     },
                     {
                       "dokument_info_id": "485201433",
-                      "tittel": "legeerklæring"
+                      "tittel": null
                     }
             ]
                 }
@@ -304,7 +304,7 @@ class K9JoarkTest {
                     },
                     {
                       "dokument_info_id": "485201433",
-                      "tittel": "legeerklæring"
+                      "tittel": null
                     }
             ]
                 }

--- a/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
+++ b/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
@@ -127,6 +127,32 @@ class K9JoarkTest {
     }
 
     @Test
+    fun `journalført respons inneholder liste med dokumentinfo`() {
+        requestAndAssert(
+            request = meldingForJournalføring(),
+            expectedResponse =
+            //language=json
+            """
+                {
+                  "journal_post_id": "2",
+                  "dokumenter": [
+                    {
+                      "dokument_info_id": "485201432",
+                      "tittel": "Søknad om omsorgspenger - utvidet rett"
+                    },
+                    {
+                      "dokument_info_id": "485201433",
+                      "tittel": "legeerklæring"
+                    }
+          ]
+                }
+                """.trimIndent(),
+            expectedCode = HttpStatusCode.Created,
+            uri = "/v1/omsorgspenge/journalforing"
+        )
+    }
+
+    @Test
     fun `Journalpost for omsorgspengeutbetaling for frilansere og selvstendig næringsdrivende`() {
         requestAndAssert(
             request = meldingForJournalføring(),
@@ -417,7 +443,7 @@ class K9JoarkTest {
 
     private fun meldingForJournalføring(
         søkerNavn: Navn? = null
-    ) : MeldingV1 {
+    ): MeldingV1 {
         val jpegDokumentId = "1234" // Default mocket som JPEG
         val pdfDokumentId = "4567"
         stubGetDokumentPdf(pdfDokumentId)

--- a/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
+++ b/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
@@ -111,7 +111,23 @@ class K9JoarkTest {
                     etternavn = "Sen"
                 )
             ),
-            expectedResponse = """{"journal_post_id":"1"}""".trimIndent(),
+            expectedResponse =
+            //language=json
+            """
+                {
+                  "journal_post_id": "1",
+                  "dokumenter": [
+                    {
+                      "dokument_info_id": "485201432",
+                      "tittel": "Søknad om omsorgspenger - utvidet rett"
+                    },
+                    {
+                      "dokument_info_id": "485201433",
+                      "tittel": "legeerklæring"
+                    }
+            ]
+                }
+                """.trimIndent(),
             expectedCode = HttpStatusCode.Created
         )
     }
@@ -120,7 +136,23 @@ class K9JoarkTest {
     fun `Journalpost for omsorgpengesøknad`() {
         requestAndAssert(
             request = meldingForJournalføring(),
-            expectedResponse = """{"journal_post_id":"2"}""".trimIndent(),
+            expectedResponse =
+            //language=json
+            """
+                {
+                  "journal_post_id": "2",
+                  "dokumenter": [
+                    {
+                      "dokument_info_id": "485201432",
+                      "tittel": "Søknad om omsorgspenger - utvidet rett"
+                    },
+                    {
+                      "dokument_info_id": "485201433",
+                      "tittel": "legeerklæring"
+                    }
+            ]
+                }
+                """.trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/omsorgspenge/journalforing"
         )
@@ -156,7 +188,23 @@ class K9JoarkTest {
     fun `Journalpost for omsorgspengeutbetaling for frilansere og selvstendig næringsdrivende`() {
         requestAndAssert(
             request = meldingForJournalføring(),
-            expectedResponse = """{"journal_post_id":"3"}""".trimIndent(),
+            expectedResponse =
+            //language=json
+            """
+                {
+                  "journal_post_id": "3",
+                  "dokumenter": [
+                    {
+                      "dokument_info_id": "485201432",
+                      "tittel": "Søknad om omsorgspenger - utvidet rett"
+                    },
+                    {
+                      "dokument_info_id": "485201433",
+                      "tittel": "legeerklæring"
+                    }
+            ]
+                }
+                """.trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/omsorgspengeutbetaling/journalforing?arbeidstype=frilanser&arbeidstype=selvstendig næringsdrivende"
         )
@@ -166,7 +214,23 @@ class K9JoarkTest {
     fun `Journalpost for omsorgpengesøknad for overføring av dager`() {
         requestAndAssert(
             request = meldingForJournalføring(),
-            expectedResponse = """{"journal_post_id":"5"}""".trimIndent(),
+            expectedResponse =
+            //language=json
+            """
+                {
+                  "journal_post_id": "5",
+                  "dokumenter": [
+                    {
+                      "dokument_info_id": "485201432",
+                      "tittel": "Søknad om omsorgspenger - utvidet rett"
+                    },
+                    {
+                      "dokument_info_id": "485201433",
+                      "tittel": "legeerklæring"
+                    }
+            ]
+                }
+                """.trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/omsorgsdageroverforing/journalforing"
         )
@@ -176,7 +240,23 @@ class K9JoarkTest {
     fun `Journalpost for omsorgspengeutbetaling for arbeidstakere`() {
         requestAndAssert(
             request = meldingForJournalføring(),
-            expectedResponse = """{"journal_post_id":"4"}""".trimIndent(),
+            expectedResponse =
+            //language=json
+            """
+                {
+                  "journal_post_id": "4",
+                  "dokumenter": [
+                    {
+                      "dokument_info_id": "485201432",
+                      "tittel": "Søknad om omsorgspenger - utvidet rett"
+                    },
+                    {
+                      "dokument_info_id": "485201433",
+                      "tittel": "legeerklæring"
+                    }
+            ]
+                }
+                """.trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/omsorgspengeutbetaling/journalforing?arbeidstype=arbeidstaker"
         )
@@ -186,7 +266,23 @@ class K9JoarkTest {
     fun `Journalpost for opplæringspengesøknad`() {
         requestAndAssert(
             request = meldingForJournalføring(),
-            expectedResponse = """{"journal_post_id":"6"}""".trimIndent(),
+            expectedResponse =
+            //language=json
+            """
+                {
+                  "journal_post_id": "6",
+                  "dokumenter": [
+                    {
+                      "dokument_info_id": "485201432",
+                      "tittel": "Søknad om omsorgspenger - utvidet rett"
+                    },
+                    {
+                      "dokument_info_id": "485201433",
+                      "tittel": "legeerklæring"
+                    }
+            ]
+                }
+                """.trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/opplæringspenge/journalforing"
         )
@@ -196,7 +292,23 @@ class K9JoarkTest {
     fun `Journalpost for frisinnsøknad`() {
         requestAndAssert(
             request = meldingForJournalføring(),
-            expectedResponse = """{"journal_post_id":"7"}""".trimIndent(),
+            expectedResponse =
+            //language=json
+            """
+                {
+                  "journal_post_id": "7",
+                  "dokumenter": [
+                    {
+                      "dokument_info_id": "485201432",
+                      "tittel": "Søknad om omsorgspenger - utvidet rett"
+                    },
+                    {
+                      "dokument_info_id": "485201433",
+                      "tittel": "legeerklæring"
+                    }
+            ]
+                }
+                """.trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/frisinn/journalforing"
         )


### PR DESCRIPTION
Liste med dokumentinfo skal muliggjøre uthenting av dokumentinfo fra dokarkiv etter at søknad er innsendt.
Dette vil tillate bruker av innsynsplattformen å kunne uthente innsendt PDF.