### PR TITLE
Legger på "- DIGITAL" på brevkode for koronaoverføring

### DIFF
--- a/src/main/kotlin/no/nav/helse/journalforing/v1/BrevkodeTittelOgTema.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/v1/BrevkodeTittelOgTema.kt
@@ -32,7 +32,7 @@ internal object BrevkodeTittelOgTema {
     )
 
     private val OMSORGSPENGER_OVERFØRING_AV_DAGER = Triple(
-        BrevKode(brevKode = "NAV 09-06.08", dokumentKategori = "SOK"),
+        BrevKode(brevKode = "NAV 09-06.08 - DIGITAL", dokumentKategori = "SOK"),
         "Søknad om overføring av omsorgsdager - NAV 09-06.08",
         Kapittel9Ytelse
     )


### PR DESCRIPTION
.. for å unngå at det blir opprettet "dobbel" oppgave når vi skal benytte den nye løsningen.

Signed-off-by: Sander Opperud Odden <sander.opperud.odden@nav.no>