### PR TITLE
Håndterer dokumentId for å hente vedlegg fra k9-mellomlagring

### DIFF
--- a/nais/dev-fss.json
+++ b/nais/dev-fss.json
@@ -16,7 +16,8 @@
     "NAIS_STS_DISCOVERY_ENDPOINT": "https://security-token-service.nais.preprod.local/rest/v1/sts/.well-known/openid-configuration",
     "AZURE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/.well-known/openid-configuration",
     "K9_DOKUMENT_SCOPE": "97f0b1bc-6aa9-4d44-a3c7-60b4318fbec4/.default",
-    "K9_MELLOMLAGRING_SCOPE": "8d0460bd-ea81-4b08-b524-cf04874a794c/.default"
+    "K9_MELLOMLAGRING_SCOPE": "8d0460bd-ea81-4b08-b524-cf04874a794c/.default",
+    "K9_MELLOMLAGRING_BASE_URL": "https://k9-mellomlagring.dev.intern.nav.no"
    },
   "slack-channel": "sif-alerts-dev",
   "slack-notify-type": "<!here> | k9-joark | ",

--- a/nais/prod-fss.json
+++ b/nais/prod-fss.json
@@ -17,6 +17,7 @@
     "AZURE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b/.well-known/openid-configuration",
     "K9_DOKUMENT_SCOPE": "0c5a6709-ba2a-42b7-bbfc-9b9f844e2ee2/.default",
     "K9_MELLOMLAGRING_SCOPE": "19aaf0b2-f40a-4a64-bf7f-fd2dd62f0552/.default",
+    "K9_MELLOMLAGRING_BASE_URL": "https://k9-mellomlagring.intern.nav.no",
     "ENABLE_OMSORGSPENGESKNAD_UTBETALING_FRILANSER_SELVSTENDIG": "true",
     "ENABLE_OMSORGSPENGESKNAD_UTBETALING_ARBEIDSTAKER": "true",
     "ENABLE_OMSORGSPENGESKNAD_MIDLERTIDIG_ALENE": "true",

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -24,6 +24,7 @@ internal data class Configuration(private val config : ApplicationConfig) {
     }
 
     internal fun getDokarkivBaseUrl() = URI(config.getRequiredString("nav.dokarkiv_base_url", secret = false))
+    internal fun getK9MellomlagringBaseUrl() = URI(config.getRequiredString("nav.k9_mellomlagring_base_url", secret = false))
 
     internal fun issuers() = config.issuers().withoutAdditionalClaimRules()
 

--- a/src/main/kotlin/no/nav/helse/K9Joark.kt
+++ b/src/main/kotlin/no/nav/helse/K9Joark.kt
@@ -75,7 +75,8 @@ fun Application.k9Joark() {
 
     val k9MellomLagringGateway = K9MellomlagringGateway(
         accessTokenClient = accessTokenClientResolver.k9Dokument(),
-        k9MellomlagringScope = configuration.getK9MellomlagringScopes()
+        k9MellomlagringScope = configuration.getK9MellomlagringScopes(),
+        k9MellomlagringBaseUrl = configuration.getK9MellomlagringBaseUrl()
     )
 
     val contentTypeService = ContentTypeService()

--- a/src/main/kotlin/no/nav/helse/journalforing/v1/JournalforingV1Service.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/v1/JournalforingV1Service.kt
@@ -142,6 +142,17 @@ class JournalforingV1Service(
         }
 
         melding.dokumentId?.let {
+            if(melding.aktoerId != null){ //Kan vurdere å legge til støtte for k9-dokument. Kun frisinn som bruker den
+                feil.add(
+                    Violation(
+                        parameterName = "dokumentId",
+                        reason = "Har ikke støtte for å hente dokumenter fra k9-dokument med dokumentId.",
+                        parameterType = ParameterType.ENTITY,
+                        invalidValue = melding.dokumentId
+                    )
+                )
+            }
+
             if(it.isEmpty()){
                 feil.add(
                     Violation(

--- a/src/main/kotlin/no/nav/helse/journalforing/v1/MeldingV1.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/v1/MeldingV1.kt
@@ -8,7 +8,8 @@ data class MeldingV1 (
     val aktoerId: String? = null,
     val mottatt: ZonedDateTime,
     val sokerNavn: Navn?,
-    val dokumenter: List<List<URI>>
+    val dokumenter: List<List<URI>>? = null,
+    val dokumentId: List<List<String>>? = null
 )
 
 data class Navn(

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -11,6 +11,7 @@ ktor {
 nav {
     dokarkiv_base_url = ""
     dokarkiv_base_url = ${?DOKARKIV_BASE_URL}
+    k9_mellomlagring_base_url = ${?K9_MELLOMLAGRING_BASE_URL}
     auth {
         issuers = [{
             alias = "azure-v1"

--- a/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
+++ b/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
@@ -536,6 +536,46 @@ class K9JoarkTest {
     }
 
     @Test
+    fun `melding med aktørId som bruker dokumentId skal feile`(){
+        val melding =  meldingForJournalføring(
+            søkerNavn = Navn(
+                fornavn = "Peie",
+                mellomnavn = "penge",
+                etternavn = "Sen"
+            )
+        )
+
+        val dokumentId = melding.dokumenter!!.map {
+            it.map { it.toString().substringAfterLast("/") }
+        }
+
+        requestAndAssert(
+            request = melding.copy(
+                dokumenter = null,
+                dokumentId = dokumentId
+            ),
+            expectedCode = HttpStatusCode.BadRequest,
+            expectedResponse = """
+                {
+                  "detail": "Requesten inneholder ugyldige paramtere.",
+                  "instance": "about:blank",
+                  "type": "/problem-details/invalid-request-parameters",
+                  "title": "invalid-request-parameters",
+                  "invalid_parameters": [
+                    {
+                      "name": "dokumentId",
+                      "reason": "Har ikke støtte for å hente dokumenter fra k9-dokument med dokumentId.",
+                      "invalid_value": [["4567", "78910"], ["1234"]],
+                      "type": "entity"
+                    }
+                  ],
+                  "status": 400
+                }
+            """.trimIndent()
+        )
+    }
+
+    @Test
     fun `melding med både dokumenter og dokumentId skal feile`(){
         val melding =  meldingForJournalføringMedDokumenterFraK9MellomLagring(
             søkerNavn = Navn(

--- a/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
+++ b/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
@@ -26,6 +26,7 @@ class K9JoarkTest {
         private val logger: Logger = LoggerFactory.getLogger(K9JoarkTest::class.java)
 
         private val wireMockServer: WireMockServer = WireMockBuilder()
+            .withPort(53854)
             .withNaisStsSupport()
             .withAzureSupport()
             .wireMockConfiguration {
@@ -133,6 +134,32 @@ class K9JoarkTest {
                     mellomnavn = "penge",
                     etternavn = "Sen"
                 )
+            ),
+            expectedResponse = """{"journal_post_id":"9"}""".trimIndent(),
+            expectedCode = HttpStatusCode.Created,
+            uri = "/v1/pleiepenge/ettersending/journalforing"
+        )
+    }
+
+    @Test
+    fun `Journalpost for pleiepengesøknad ettersending med dokumentId`() {
+        val melding =  meldingForJournalføringMedDokumenterFraK9MellomLagring(
+            søkerNavn = Navn(
+                fornavn = "Peie",
+                mellomnavn = "penge",
+                etternavn = "Sen"
+            ),
+            norskIdent = "12345678910"
+        )
+
+        val dokumentId = melding.dokumenter!!.map {
+            it.map { it.toString().substringAfterLast("/") }
+        }
+
+        requestAndAssert(
+            request = melding.copy(
+                dokumenter = null,
+                dokumentId = dokumentId
             ),
             expectedResponse = """{"journal_post_id":"9"}""".trimIndent(),
             expectedCode = HttpStatusCode.Created,
@@ -448,7 +475,7 @@ class K9JoarkTest {
                 "instance": "about:blank",
                 "invalid_parameters": [{
                     "type": "entity",
-                    "name": "dokument",
+                    "name": "dokumenter",
                     "reason": "Det må sendes minst ett dokument",
                     "invalid_value": []
                 },
@@ -497,12 +524,52 @@ class K9JoarkTest {
                     "instance": "about:blank",
                     "invalid_parameters" : [
                         {
-                            "name" : "dokument_bolk",
+                            "name" : "dokumenter.dokument_bolk",
                             "reason" : "Det må være minst et dokument i en dokument bolk.",
                             "type": "entity",
                             "invalid_value": []
                         }
                     ]
+                }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `melding med både dokumenter og dokumentId skal feile`(){
+        val melding =  meldingForJournalføringMedDokumenterFraK9MellomLagring(
+            søkerNavn = Navn(
+                fornavn = "Peie",
+                mellomnavn = "penge",
+                etternavn = "Sen"
+            ),
+            norskIdent = "12345678910"
+        )
+
+        val dokumentId = melding.dokumenter!!.map {
+            it.map { it.toString().substringAfterLast("/") }
+        }
+
+        requestAndAssert(
+            request = melding.copy(
+                dokumentId = dokumentId
+            ),
+            expectedCode = HttpStatusCode.BadRequest,
+            expectedResponse = """
+                {
+                  "detail": "Requesten inneholder ugyldige paramtere.",
+                  "instance": "about:blank",
+                  "type": "/problem-details/invalid-request-parameters",
+                  "title": "invalid-request-parameters",
+                  "invalid_parameters": [
+                    {
+                      "name": "dokumenter, dokumentId",
+                      "reason": "Kun en av dokumentId og dokumenter kan være satt, ikke begge.",
+                      "invalid_value": "[[http://localhost:53854/k9-mellomlagring/4567, http://localhost:53854/k9-mellomlagring/78910], [http://localhost:53854/k9-mellomlagring/1234]], [[4567, 78910], [1234]]",
+                      "type": "entity"
+                    }
+                  ],
+                  "status": 400
                 }
             """.trimIndent()
         )

--- a/src/test/kotlin/no/nav/helse/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/helse/TestConfiguration.kt
@@ -12,11 +12,13 @@ object TestConfiguration {
         wireMockServer: WireMockServer? = null,
         port : Int = 8080,
         dokarkivUrl : String? = wireMockServer?.getDokarkivUrl(),
+        k9MellomlagringUrl: String? = wireMockServer?.getK9MellomlagringUrl(),
         k9JoarkAzureClientId: String = "pleiepenger-joark"
     ) : Map<String, String>{
         val map = mutableMapOf(
             Pair("ktor.deployment.port","$port"),
-            Pair("nav.dokarkiv_base_url", "$dokarkivUrl")
+            Pair("nav.dokarkiv_base_url", "$dokarkivUrl"),
+            Pair("nav.k9_mellomlagring_base_url", "$k9MellomlagringUrl")
         )
 
         // Clients


### PR DESCRIPTION
Legger til støtte for å hente dokumenter fra k9-mellomlagring basert på dokumentId i stedet for å være koblet til hva slags url api/prosessering bruker. 

Støtter begge variantene(dokumentId/dokumenter).

Legger ikke til støtte for å hente dokumenter fra k9-dokument i førsteomgang. Det er kun frisinn som bruker den og vil egentlig ikke røre de mer enn nødvendig. 