### PR TITLE
Fjerner gammelt felt og logikk, refaktorering og oppdatering av pakker. 

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v3.3.0
+        uses: actions/setup-java@v3.4.1
         with:
           java-version: 17
           distribution: 'zulu'
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v3.3.0
+        uses: actions/setup-java@v3.4.1
         with:
           java-version: 17
           distribution: 'zulu'

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Inneholder integrasjon mot joark for å opprette journalpost i forbindelse med s
 - norsk_ident: Norsk ident for personen dokumentene skal journalføres på
 - soker_navn: Navn på personen dokumente skal journalføres på. Denner optional, og om satt er også mellomnavn optional.
 - mottatt : tidspunkt for når dokumentene er mottatt på ISO8601 format
-- dokumenter : En liste med lister av URL'er til dokumenter som skal journalføres som må peke på "k9-mellomlagring"
-- dokumenter : Må inneholde minst en liste, og hvert liste må inneholde minst en entry.
+- dokumentId : En liste med lister av ID'er til dokumenter lagret i k9-mellomlagring som skal journalføres som må peke på "k9-mellomlagring"
+- dokumentId : Må inneholde minst en liste, og hvert liste må inneholde minst en entry.
 - dokumenter[0] : Vil bli "Hoveddokument" i Joark
 - En liste med URL'er skal være > 1 om man ønsker å journalføre samme dokument på forskjellige format. For eksempel PDF & JSON
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,16 +4,16 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 val dusseldorfKtorVersion = "3.2.0.2-b18c5fe"
 val ktorVersion = ext.get("ktorVersion").toString()
 val pdfBoxVersion = "2.0.26"
-val imageIOVersion = "3.8.2"
-val jsonassertVersion = "1.5.0"
+val imageIOVersion = "3.8.3"
+val jsonassertVersion = "1.5.1"
 val fuelVersion = "2.3.1"
-val tokenSupportVersion = "2.1.0"
+val tokenSupportVersion = "2.1.3"
 val mockOauth2ServerVersion = "0.5.1"
 
 val mainClass = "no.nav.helse.K9JoarkKt"
 
 plugins {
-    kotlin("jvm") version "1.7.0"
+    kotlin("jvm") version "1.7.10"
     id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 

--- a/src/main/kotlin/no/nav/helse/dokument/DokumentService.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/DokumentService.kt
@@ -37,23 +37,6 @@ class DokumentService(
         return håndterDokumenter(alleDokumenter)
     }
 
-    suspend fun hentDokumenter(
-        urls: List<URI>,
-        fodselsnummer: Fodselsnummer,
-        correlationId: CorrelationId
-    ): List<Dokument> {
-        logger.trace("Henter ${urls.size} dokumenter.")
-
-        logger.info("Henter dokumenter fra k9-mellomlagring")
-        val alleDokumenter = k9MellomlagringGateway.hentDokumenter(
-            urls = urls,
-            eiersFodselsnummer = fodselsnummer,
-            correlationId = correlationId
-        )
-
-        return håndterDokumenter(alleDokumenter)
-    }
-
     fun håndterDokumenter(dokumenter: List<Dokument>): List<Dokument> {
         dokumenter.tellContentType()
 

--- a/src/main/kotlin/no/nav/helse/dokument/mellomlagring/K9MellomlagringGateway.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/mellomlagring/K9MellomlagringGateway.kt
@@ -57,29 +57,6 @@ class K9MellomlagringGateway(
         }
     }
 
-    suspend fun hentDokumenter(
-        urls : List<URI>,
-        eiersFodselsnummer: Fodselsnummer,
-        correlationId: CorrelationId
-    ) : List<Dokument> {
-        val authorizationHeader = cachedAccessTokenClient.getAccessToken(k9MellomlagringScope).asAuthoriationHeader()
-
-        return Operation.monitored(
-            app = "k9-joark",
-            operation = HENTE_ALLE_DOKUMENTER_OPERATION
-        ) {
-            coroutineScope {
-                val futures = mutableListOf<Deferred<Dokument>>()
-                urls.forEach { url ->
-                    futures.add(async {
-                        hentDokument(url, eiersFodselsnummer, authorizationHeader, correlationId)
-                    })
-                }
-                futures.awaitAll()
-            }
-        }
-    }
-
     suspend fun hentDokumenterMedDokumentId(
         dokumentId : List<String>,
         eiersFodselsnummer: Fodselsnummer,

--- a/src/main/kotlin/no/nav/helse/journalforing/api/JournalforingApis.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/api/JournalforingApis.kt
@@ -1,21 +1,17 @@
 package no.nav.helse.journalforing.api
 
-import io.ktor.server.application.call
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.*
-import io.ktor.server.request.ApplicationRequest
-import io.ktor.server.request.header
-import io.ktor.server.request.receive
-import io.ktor.server.response.ApplicationResponse
-import io.ktor.server.response.respond
-import io.ktor.server.routing.Route
-import io.ktor.server.routing.post
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import io.ktor.util.pipeline.PipelineContext
 import no.nav.helse.journalforing.v1.JournalforingV1Service
 import no.nav.helse.journalforing.v1.MeldingV1
 import no.nav.helse.journalforing.v1.MetadataV1
 import no.nav.helse.journalforing.v1.Søknadstype
+import no.nav.helse.journalforing.v1.Søknadstype.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -42,68 +38,38 @@ fun Route.journalforingApis(journalforingV1Service: JournalforingV1Service) {
 
     post("/v1/pleiepenge/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(
-            version = 1,
-            correlationId = call.request.getCorrelationId(),
-            requestId = call.response.getRequestId(),
-            søknadstype = Søknadstype.PLEIEPENGESØKNAD
-        )
+        val metadata = call.genererMetadata(PLEIEPENGESØKNAD)
         journalfør(melding, metadata)
     }
 
     post("/v1/pleiepenge/ettersending/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(
-            version = 1,
-            correlationId = call.request.getCorrelationId(),
-            requestId = call.response.getRequestId(),
-            søknadstype = Søknadstype.PLEIEPENGESØKNAD_ETTERSENDING
-        )
+        val metadata = call.genererMetadata(PLEIEPENGESØKNAD_ETTERSENDING)
         journalfør(melding, metadata)
     }
 
     post("/v1/pleiepenge/livets-sluttfase/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(
-            version = 1,
-            correlationId = call.request.getCorrelationId(),
-            requestId = call.response.getRequestId(),
-            søknadstype = Søknadstype.PLEIEPENGESØKNAD_LIVETS_SLUTTFASE
-        )
+        val metadata = call.genererMetadata(PLEIEPENGESØKNAD_LIVETS_SLUTTFASE)
         journalfør(melding, metadata)
     }
 
     post("/v1/pleiepenge/livets-sluttfase/ettersending/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(
-            version = 1,
-            correlationId = call.request.getCorrelationId(),
-            requestId = call.response.getRequestId(),
-            søknadstype = Søknadstype.PLEIEPENGESØKNAD_LIVETS_SLUTTFASE_ETTERSENDING
-        )
+        val metadata = call.genererMetadata(PLEIEPENGESØKNAD_LIVETS_SLUTTFASE_ETTERSENDING)
         journalfør(melding, metadata)
     }
 
 
     post("/v1/omsorgspenge/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(
-            version = 1,
-            correlationId = call.request.getCorrelationId(),
-            requestId = call.response.getRequestId(),
-            søknadstype = Søknadstype.OMSORGSPENGESØKNAD
-        )
+        val metadata = call.genererMetadata(OMSORGSPENGESØKNAD)
         journalfør(melding, metadata)
     }
 
     post("/v1/omsorgspenge/ettersending/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(
-            version = 1,
-            correlationId = call.request.getCorrelationId(),
-            requestId = call.response.getRequestId(),
-            søknadstype = Søknadstype.OMSORGSPENGESØKNAD_ETTERSENDING
-        )
+        val metadata = call.genererMetadata(OMSORGSPENGESØKNAD_ETTERSENDING)
         journalfør(melding, metadata)
     }
 
@@ -111,12 +77,12 @@ fun Route.journalforingApis(journalforingV1Service: JournalforingV1Service) {
         when {
             call.request.gjelderFrilanserOgSelvstendigNæringsdrivende() -> {
                 val melding = call.receive<MeldingV1>()
-                val metadata = MetadataV1(version = 1, correlationId = call.request.getCorrelationId(), requestId = call.response.getRequestId(), søknadstype = Søknadstype.OMSORGSPENGESØKNAD_UTBETALING_FRILANSER_SELVSTENDIG)
+                val metadata = call.genererMetadata(OMSORGSPENGESØKNAD_UTBETALING_FRILANSER_SELVSTENDIG)
                 journalfør(melding, metadata)
             }
             call.request.gjelderArbeidstaker() -> {
                 val melding = call.receive<MeldingV1>()
-                val metadata = MetadataV1(version = 1, correlationId = call.request.getCorrelationId(), requestId = call.response.getRequestId(), søknadstype = Søknadstype.OMSORGSPENGESØKNAD_UTBETALING_ARBEIDSTAKER)
+                val metadata = call.genererMetadata(OMSORGSPENGESØKNAD_UTBETALING_ARBEIDSTAKER)
                 journalfør(melding, metadata)
             }
             else -> call.response.status(HttpStatusCode.NotFound)
@@ -127,22 +93,12 @@ fun Route.journalforingApis(journalforingV1Service: JournalforingV1Service) {
         when {
             call.request.gjelderFrilanserOgSelvstendigNæringsdrivende() -> {
                 val melding = call.receive<MeldingV1>()
-                val metadata = MetadataV1(
-                    version = 1,
-                    correlationId = call.request.getCorrelationId(),
-                    requestId = call.response.getRequestId(),
-                    søknadstype = Søknadstype.OMSORGSPENGESØKNAD_UTBETALING_FRILANSER_SELVSTENDIG_ETTERSENDING
-                )
+                val metadata = call.genererMetadata(OMSORGSPENGESØKNAD_UTBETALING_FRILANSER_SELVSTENDIG_ETTERSENDING)
                 journalfør(melding, metadata)
             }
             call.request.gjelderArbeidstaker() -> {
                 val melding = call.receive<MeldingV1>()
-                val metadata = MetadataV1(
-                    version = 1,
-                    correlationId = call.request.getCorrelationId(),
-                    requestId = call.response.getRequestId(),
-                    søknadstype = Søknadstype.OMSORGSPENGESØKNAD_UTBETALING_ARBEIDSTAKER_ETTERSENDING
-                )
+                val metadata = call.genererMetadata(OMSORGSPENGESØKNAD_UTBETALING_ARBEIDSTAKER_ETTERSENDING)
                 journalfør(melding, metadata)
             }
             else -> call.response.status(HttpStatusCode.NotFound)
@@ -151,67 +107,59 @@ fun Route.journalforingApis(journalforingV1Service: JournalforingV1Service) {
 
     post("/v1/omsorgsdageroverforing/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(version = 1, correlationId = call.request.getCorrelationId(), requestId = call.response.getRequestId(), søknadstype = Søknadstype.OMSORGSPENGESØKNAD_OVERFØRING_AV_DAGER)
+        val metadata = call.genererMetadata(OMSORGSPENGESØKNAD_OVERFØRING_AV_DAGER)
         journalfør(melding, metadata)
     }
 
     post("/v1/omsorgsdagerdeling/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(version = 1, correlationId = call.request.getCorrelationId(), requestId = call.response.getRequestId(), søknadstype = Søknadstype.OMSORGSPENGEMELDING_DELING_AV_DAGER)
+        val metadata = call.genererMetadata(OMSORGSPENGEMELDING_DELING_AV_DAGER)
         journalfør(melding, metadata)
     }
 
     post("/v1/omsorgsdagerdeling/ettersending/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(
-            version = 1,
-            correlationId = call.request.getCorrelationId(),
-            requestId = call.response.getRequestId(),
-            søknadstype = Søknadstype.OMSORGSPENGEMELDING_DELING_AV_DAGER_ETTERSENDING
-        )
+        val metadata = call.genererMetadata(OMSORGSPENGEMELDING_DELING_AV_DAGER_ETTERSENDING)
         journalfør(melding, metadata)
     }
 
     post("/v1/opplæringspenge/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(version = 1, correlationId = call.request.getCorrelationId(), requestId = call.response.getRequestId(), søknadstype = Søknadstype.OPPLÆRINGSPENGESØKNAD)
+        val metadata = call.genererMetadata(OPPLÆRINGSPENGESØKNAD)
         journalfør(melding, metadata)
     }
 
     post("/v1/frisinn/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(version = 1, correlationId = call.request.getCorrelationId(), requestId = call.response.getRequestId(), søknadstype = Søknadstype.FRISINNSØKNAD)
+        val metadata = call.genererMetadata(FRISINNSØKNAD)
         journalfør(melding, metadata)
     }
 
     post("/v1/omsorgspenger/midlertidig-alene/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(version = 1, correlationId = call.request.getCorrelationId(), requestId = call.response.getRequestId(), søknadstype = Søknadstype.OMSORGSPENGESØKNAD_MIDLERTIDIG_ALENE)
+        val metadata = call.genererMetadata(OMSORGSPENGESØKNAD_MIDLERTIDIG_ALENE)
         journalfør(melding, metadata)
     }
 
     post("/v1/omsorgspenger/midlertidig-alene/ettersending/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(
-            version = 1,
-            correlationId = call.request.getCorrelationId(),
-            requestId = call.response.getRequestId(),
-            søknadstype = Søknadstype.OMSORGSPENGESØKNAD_MIDLERTIDIG_ALENE_ETTERSENDING
-        )
+        val metadata = call.genererMetadata(OMSORGSPENGESØKNAD_MIDLERTIDIG_ALENE_ETTERSENDING)
         journalfør(melding, metadata)
     }
 
     post("/v1/omsorgsdager/aleneomsorg/journalforing") {
         val melding = call.receive<MeldingV1>()
-        val metadata = MetadataV1(
-            version = 1,
-            correlationId = call.request.getCorrelationId(),
-            requestId = call.response.getRequestId(),
-            søknadstype = Søknadstype.OMSORGSDAGER_ALENEOMSORG
-        )
+        val metadata = call.genererMetadata(OMSORGSDAGER_ALENEOMSORG)
         journalfør(melding, metadata)
     }
 }
+
+private fun ApplicationCall.genererMetadata(søknadstype: Søknadstype, version: Int = 1) = MetadataV1(
+    version = version,
+    correlationId = this.request.getCorrelationId(),
+    requestId = this.response.getRequestId(),
+    søknadstype = søknadstype
+)
 
 private fun ApplicationRequest.gjelderFrilanserOgSelvstendigNæringsdrivende() : Boolean {
     val arbeidstyper = queryParameters.getAll("arbeidstype")?: emptyList()

--- a/src/main/kotlin/no/nav/helse/journalforing/v1/JournalforingV1Service.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/v1/JournalforingV1Service.kt
@@ -46,21 +46,11 @@ class JournalforingV1Service(
         logger.trace("Henter dokumenter")
         val alleDokumenter = mutableListOf<List<Dokument>>()
 
-        melding.dokumentId?.forEach { dokumentId ->
+        melding.dokumentId.forEach { dokumentId ->
             logger.info("Henter dokumenter basert på dokumentId")
             alleDokumenter.add(
                 dokumentService.hentDokumenterMedDokumentId(
                     dokumentId = dokumentId,
-                    correlationId = correlationId,
-                    fodselsnummer = fodselsnummer
-                )
-            )
-        }
-
-        melding.dokumenter?.forEach {
-            alleDokumenter.add(
-                dokumentService.hentDokumenter(
-                    urls = it,
                     correlationId = correlationId,
                     fodselsnummer = fodselsnummer
                 )
@@ -92,77 +82,27 @@ class JournalforingV1Service(
     private fun validerDokumenter(melding: MeldingV1): MutableSet<Violation> {
         val feil = mutableSetOf<Violation>()
 
-        if(melding.dokumentId == null && melding.dokumenter == null){
+        if (melding.dokumentId.isEmpty()) {
             feil.add(
                 Violation(
-                    parameterName = "dokumenter, dokumentId",
-                    reason = "dokumentId eller dokumenter må være satt. Ikke begge kan være null.",
+                    parameterName = "dokumentId",
+                    reason = "Det må sendes minst ett dokument",
                     parameterType = ParameterType.ENTITY,
-                    invalidValue = "${melding.dokumenter}, ${melding.dokumentId}"
+                    invalidValue = melding.dokumentId
                 )
             )
         }
 
-        if(melding.dokumentId != null && melding.dokumenter != null){
-            feil.add(
-                Violation(
-                    parameterName = "dokumenter, dokumentId",
-                    reason = "Kun en av dokumentId og dokumenter kan være satt, ikke begge.",
-                    parameterType = ParameterType.ENTITY,
-                    invalidValue = "${melding.dokumenter}, ${melding.dokumentId}"
-                )
-            )
-        }
-
-        melding.dokumenter?.let {
-            if(it.isEmpty()){
+        melding.dokumentId.forEach { dokumentBolk ->
+            if (dokumentBolk.isEmpty()) {
                 feil.add(
                     Violation(
-                        parameterName = "dokumenter",
-                        reason = "Det må sendes minst ett dokument",
+                        parameterName = "dokumentId.dokument_bolk",
+                        reason = "Det må være minst et dokument i en dokument bolk.",
                         parameterType = ParameterType.ENTITY,
-                        invalidValue = melding.dokumenter
+                        invalidValue = dokumentBolk
                     )
                 )
-            }
-
-            it.forEach { dokumentBolk ->
-                if (dokumentBolk.isEmpty()) {
-                    feil.add(
-                        Violation(
-                            parameterName = "dokumenter.dokument_bolk",
-                            reason = "Det må være minst et dokument i en dokument bolk.",
-                            parameterType = ParameterType.ENTITY,
-                            invalidValue = dokumentBolk
-                        )
-                    )
-                }
-            }
-        }
-
-        melding.dokumentId?.let {
-            if(it.isEmpty()){
-                feil.add(
-                    Violation(
-                        parameterName = "dokumentId",
-                        reason = "Det må sendes minst ett dokument",
-                        parameterType = ParameterType.ENTITY,
-                        invalidValue = melding.dokumentId
-                    )
-                )
-            }
-
-            it.forEach { dokumentBolk ->
-                if (dokumentBolk.isEmpty()) {
-                    feil.add(
-                        Violation(
-                            parameterName = "dokumentId.dokument_bolk",
-                            reason = "Det må være minst et dokument i en dokument bolk.",
-                            parameterType = ParameterType.ENTITY,
-                            invalidValue = dokumentBolk
-                        )
-                    )
-                }
             }
         }
 

--- a/src/main/kotlin/no/nav/helse/journalforing/v1/MeldingV1.kt
+++ b/src/main/kotlin/no/nav/helse/journalforing/v1/MeldingV1.kt
@@ -1,14 +1,12 @@
 package no.nav.helse.journalforing.v1
 
-import java.net.URI
 import java.time.ZonedDateTime
 
 data class MeldingV1 (
     val norskIdent: String,
     val mottatt: ZonedDateTime,
     val sokerNavn: Navn?,
-    val dokumenter: List<List<URI>>? = null,
-    val dokumentId: List<List<String>>? = null
+    val dokumentId: List<List<String>>
 )
 
 data class Navn(

--- a/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
+++ b/src/test/kotlin/no/nav/helse/K9JoarkTest.kt
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.skyscreamer.jsonassert.JSONAssert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.net.URI
 import java.time.ZonedDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -98,13 +97,7 @@ class K9JoarkTest {
     @Test
     fun `Journalpost for pleiepengesøknad`() {
         requestAndAssert(
-            request = meldingForJournalføring(
-                søkerNavn = Navn(
-                    fornavn = "Peie",
-                    mellomnavn = "penge",
-                    etternavn = "Sen"
-                )
-            ),
+            request = meldingForJournalføring(),
             expectedResponse = """{"journal_post_id":"1"}""".trimIndent(),
             expectedCode = HttpStatusCode.Created
         )
@@ -113,13 +106,7 @@ class K9JoarkTest {
     @Test
     fun `Journalpost for pleiepenger livets sluttfase`() {
         requestAndAssert(
-            request = meldingForJournalføring(
-                søkerNavn = Navn(
-                    fornavn = "Pleiepenger",
-                    mellomnavn = "Livets",
-                    etternavn = "Sluttfase"
-                )
-            ),
+            request = meldingForJournalføring(),
             expectedResponse = """{"journal_post_id":"16"}""".trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/pleiepenge/livets-sluttfase/journalforing"
@@ -129,13 +116,7 @@ class K9JoarkTest {
     @Test
     fun `Journalpost for pleiepenger livets sluttfase ettersending`() {
         requestAndAssert(
-            request = meldingForJournalføring(
-                søkerNavn = Navn(
-                    fornavn = "Pleiepenger",
-                    mellomnavn = "Livets",
-                    etternavn = "Sluttfase Ettersending"
-                )
-            ),
+            request = meldingForJournalføring(),
             expectedResponse = """{"journal_post_id":"17"}""".trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/pleiepenge/livets-sluttfase/ettersending/journalforing"
@@ -145,39 +126,7 @@ class K9JoarkTest {
     @Test
     fun `Journalpost for pleiepengesøknad ettersending`() {
         requestAndAssert(
-            request = meldingForJournalføring(
-                søkerNavn = Navn(
-                    fornavn = "Peie",
-                    mellomnavn = "penge",
-                    etternavn = "Sen"
-                )
-            ),
-            expectedResponse = """{"journal_post_id":"9"}""".trimIndent(),
-            expectedCode = HttpStatusCode.Created,
-            uri = "/v1/pleiepenge/ettersending/journalforing"
-        )
-    }
-
-    @Test
-    fun `Journalpost for pleiepengesøknad ettersending med dokumentId`() {
-        val melding =  meldingForJournalføringMedDokumenterFraK9MellomLagring(
-            søkerNavn = Navn(
-                fornavn = "Peie",
-                mellomnavn = "penge",
-                etternavn = "Sen"
-            ),
-            norskIdent = "012345678901"
-        )
-
-        val dokumentId = melding.dokumenter!!.map {
-            it.map { it.toString().substringAfterLast("/") }
-        }
-
-        requestAndAssert(
-            request = melding.copy(
-                dokumenter = null,
-                dokumentId = dokumentId
-            ),
+            request = meldingForJournalføring(),
             expectedResponse = """{"journal_post_id":"9"}""".trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/pleiepenge/ettersending/journalforing"
@@ -287,14 +236,7 @@ class K9JoarkTest {
     @Test
     fun `Journalpost for omsorgspenger - midlertidig alene`() {
         requestAndAssert(
-            request = meldingForJournalføringMedDokumenterFraK9MellomLagring(
-                søkerNavn = Navn(
-                    fornavn = "Peie",
-                    mellomnavn = "penge",
-                    etternavn = "Sen"
-                ),
-                norskIdent = "012345678901"
-            ),
+            request = meldingForJournalføring(),
             expectedResponse = """{"journal_post_id":"8"}""".trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/omsorgspenger/midlertidig-alene/journalforing"
@@ -304,14 +246,7 @@ class K9JoarkTest {
     @Test
     fun `Journalpost for omsorgspenger ettersending - midlertidig alene`() {
         requestAndAssert(
-            request = meldingForJournalføringMedDokumenterFraK9MellomLagring(
-                søkerNavn = Navn(
-                    fornavn = "Peie",
-                    mellomnavn = "penge",
-                    etternavn = "Sen"
-                ),
-                norskIdent = "012345678901"
-            ),
+            request = meldingForJournalføring(),
             expectedResponse = """{"journal_post_id":"13"}""".trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/omsorgspenger/midlertidig-alene/ettersending/journalforing"
@@ -321,14 +256,7 @@ class K9JoarkTest {
     @Test
     fun `Journalpost for omsorgsdager aleneomsorg`() {
         requestAndAssert(
-            request = meldingForJournalføringMedDokumenterFraK9MellomLagring(
-                søkerNavn = Navn(
-                    fornavn = "Peie",
-                    mellomnavn = "penge",
-                    etternavn = "Sen"
-                ),
-                norskIdent = "012345678901"
-            ),
+            request = meldingForJournalføring(),
             expectedResponse = """{"journal_post_id":"15"}""".trimIndent(),
             expectedCode = HttpStatusCode.Created,
             uri = "/v1/omsorgsdager/aleneomsorg/journalforing"
@@ -337,24 +265,8 @@ class K9JoarkTest {
 
     @Test
     fun `melding uten correlation id skal feile`() {
-        val request = MeldingV1(
-            norskIdent = "12345",
-            mottatt = ZonedDateTime.now(),
-            dokumenter = listOf(
-                listOf(
-                    getK9MellomlagringDokumentUrl("1234"),
-                    getK9MellomlagringDokumentUrl("5678")
-                )
-            ),
-            sokerNavn = Navn(
-                fornavn = "ole",
-                etternavn = "Nordmann"
-            )
-        )
-
-
         requestAndAssert(
-            request = request,
+            request = meldingForJournalføring(),
             leggTilCorrelationId = false,
             expectedCode = HttpStatusCode.BadRequest,
             expectedResponse = """
@@ -378,23 +290,8 @@ class K9JoarkTest {
 
     @Test
     fun `mangler authorization header`() {
-        val request = MeldingV1(
-            norskIdent = "12345",
-            mottatt = ZonedDateTime.now(),
-            dokumenter = listOf(
-                listOf(
-                    getK9MellomlagringDokumentUrl("1234"),
-                    getK9MellomlagringDokumentUrl("5678")
-                )
-            ),
-            sokerNavn = Navn(
-                fornavn = "ole",
-                etternavn = "Nordmann"
-            )
-        )
-
         requestAndAssert(
-            request = request,
+            request = meldingForJournalføring(),
             leggTilAuthorization = false,
             expectedCode = HttpStatusCode.Unauthorized,
             expectedResponse = null
@@ -403,21 +300,6 @@ class K9JoarkTest {
 
     @Test
     fun `request fra ikke tillatt system`() {
-        val request = MeldingV1(
-            norskIdent = "12345",
-            mottatt = ZonedDateTime.now(),
-            dokumenter = listOf(
-                listOf(
-                    getK9MellomlagringDokumentUrl("1234"),
-                    getK9MellomlagringDokumentUrl("5678")
-                )
-            ),
-            sokerNavn = Navn(
-                fornavn = "ole",
-                etternavn = "Nordmann"
-            )
-        )
-
         val feilAuidence = mockOAuth2Server.issueToken(
             issuerId = "azure",
             audience = "dev-gcp:dusseldorf:k9-mellomlagring",
@@ -431,14 +313,14 @@ class K9JoarkTest {
         ).serialize()
 
         requestAndAssert(
-            request = request,
+            request = meldingForJournalføring(),
             expectedCode = HttpStatusCode.Unauthorized,
             accessToken = feilAuidence,
             expectedResponse = null
         )
 
         requestAndAssert(
-            request = request,
+            request = meldingForJournalføring(),
             expectedCode = HttpStatusCode.Unauthorized,
             accessToken = ikkeAuthorizedApplication,
             expectedResponse = null
@@ -447,18 +329,8 @@ class K9JoarkTest {
 
     @Test
     fun `melding uten dokumenter skal feile`() {
-        val request = MeldingV1(
-            norskIdent = "012345678901F",
-            mottatt = ZonedDateTime.now(),
-            dokumenter = listOf(),
-            sokerNavn = Navn(
-                fornavn = "ole",
-                etternavn = "Nordmann"
-            )
-        )
-
         requestAndAssert(
-            request = request,
+            request = meldingForJournalføring().copy(dokumentId = emptyList()),
             expectedCode = HttpStatusCode.BadRequest,
             expectedResponse = """
             {
@@ -469,15 +341,9 @@ class K9JoarkTest {
                 "instance": "about:blank",
                 "invalid_parameters": [{
                     "type": "entity",
-                    "name": "dokumenter",
+                    "name": "dokumentId",
                     "reason": "Det må sendes minst ett dokument",
                     "invalid_value": []
-                },
-                {
-                    "type": "entity",
-                    "name": "norsk_ident",
-                    "reason": "Ugyldig Norsk Ident. Kan kun være siffer.",
-                    "invalid_value": "012345678901F"
                 }]          
             }
             """.trimIndent()
@@ -486,21 +352,10 @@ class K9JoarkTest {
 
     @Test
     fun `melding med tomme dokumentbolker skal feile`() {
-        val request = MeldingV1(
-            norskIdent = "012345678901",
-            mottatt = ZonedDateTime.now(),
-            dokumenter = listOf(
-                listOf(getK9MellomlagringDokumentUrl("1234")),
-                listOf()
-            ),
-            sokerNavn = Navn(
-                fornavn = "ole",
-                etternavn = "Nordmann"
-            )
-        )
-
         requestAndAssert(
-            request = request,
+            request = meldingForJournalføring().copy(
+                dokumentId = listOf(listOf("123"), emptyList())
+            ),
             expectedCode = HttpStatusCode.BadRequest,
             expectedResponse = """
                 {
@@ -511,7 +366,7 @@ class K9JoarkTest {
                     "instance": "about:blank",
                     "invalid_parameters" : [
                         {
-                            "name" : "dokumenter.dokument_bolk",
+                            "name" : "dokumentId.dokument_bolk",
                             "reason" : "Det må være minst et dokument i en dokument bolk.",
                             "type": "entity",
                             "invalid_value": []
@@ -521,48 +376,6 @@ class K9JoarkTest {
             """.trimIndent()
         )
     }
-
-    @Test
-    fun `melding med både dokumenter og dokumentId skal feile`(){
-        val melding =  meldingForJournalføringMedDokumenterFraK9MellomLagring(
-            søkerNavn = Navn(
-                fornavn = "Peie",
-                mellomnavn = "penge",
-                etternavn = "Sen"
-            ),
-            norskIdent = "12345678910"
-        )
-
-        val dokumentId = melding.dokumenter!!.map {
-            it.map { it.toString().substringAfterLast("/") }
-        }
-
-        requestAndAssert(
-            request = melding.copy(
-                dokumentId = dokumentId
-            ),
-            expectedCode = HttpStatusCode.BadRequest,
-            expectedResponse = """
-                {
-                  "detail": "Requesten inneholder ugyldige paramtere.",
-                  "instance": "about:blank",
-                  "type": "/problem-details/invalid-request-parameters",
-                  "title": "invalid-request-parameters",
-                  "invalid_parameters": [
-                    {
-                      "name": "dokumenter, dokumentId",
-                      "reason": "Kun en av dokumentId og dokumenter kan være satt, ikke begge.",
-                      "invalid_value": "[[http://localhost:53854/k9-mellomlagring/4567, http://localhost:53854/k9-mellomlagring/78910], [http://localhost:53854/k9-mellomlagring/1234]], [[4567, 78910], [1234]]",
-                      "type": "entity"
-                    }
-                  ],
-                  "status": 400
-                }
-            """.trimIndent()
-        )
-    }
-
-    private fun getK9MellomlagringDokumentUrl(dokumentId: String) = URI("${wireMockServer.getK9MellomlagringUrl()}/$dokumentId")
 
     private fun requestAndAssert(
         request: MeldingV1,
@@ -594,7 +407,7 @@ class K9JoarkTest {
     }
 
     private fun meldingForJournalføring(
-        søkerNavn: Navn? = null
+        søkerNavn: Navn? = Navn("Ole", "Nordmann", "Noo")
     ): MeldingV1 {
         val jpegDokumentId = "1234" // Default mocket som JPEG
         val pdfDokumentId = "4567"
@@ -603,40 +416,9 @@ class K9JoarkTest {
         return MeldingV1(
             norskIdent = "012345678901",
             mottatt = ZonedDateTime.now(),
-            dokumenter = listOf(
-                listOf(
-                    getK9MellomlagringDokumentUrl(pdfDokumentId),
-                    getK9MellomlagringDokumentUrl(jsonDokumentId)
-                ),
-                listOf(
-                    getK9MellomlagringDokumentUrl(jpegDokumentId)
-                )
-            ),
-            sokerNavn = søkerNavn
-        )
-    }
-
-    private fun meldingForJournalføringMedDokumenterFraK9MellomLagring(
-        søkerNavn: Navn? = null,
-        norskIdent: String,
-    ): MeldingV1 {
-        val jpegDokumentId = "1234" // Default mocket som JPEG
-        val pdfDokumentId = "4567"
-        stubGetDokumentPdfFraK9Mellomlagring(norskIdent, pdfDokumentId)
-        val jsonDokumentId = "78910"
-        stubGetDokumentJsonFraK9Mellomlagring(norskIdent, jsonDokumentId)
-
-        return MeldingV1(
-            norskIdent = norskIdent,
-            mottatt = ZonedDateTime.now(),
-            dokumenter = listOf(
-                listOf(
-                    getK9MellomlagringDokumentUrl(pdfDokumentId),
-                    getK9MellomlagringDokumentUrl(jsonDokumentId)
-                ),
-                listOf(
-                    getK9MellomlagringDokumentUrl(jpegDokumentId)
-                )
+            dokumentId = listOf(
+                listOf(pdfDokumentId, jsonDokumentId),
+                listOf(jpegDokumentId)
             ),
             sokerNavn = søkerNavn
         )

--- a/src/test/kotlin/no/nav/helse/WireMockStubs.kt
+++ b/src/test/kotlin/no/nav/helse/WireMockStubs.kt
@@ -64,56 +64,5 @@ internal fun WireMockServer.stubGetDokumentFraK9Mellomlagring(eiersFødselsnumme
     return this
 }
 
-internal fun stubGetDokumentJsonFraK9Mellomlagring(eiersFødselsnummer: String, dokumentId: String) {
-    val content = Base64.getEncoder().encodeToString("jwkset.json".fromResources().readBytes())
-    WireMock.stubFor(
-        WireMock.post(WireMock.urlPathMatching(".*$k9MellomlagringPath.*/$dokumentId"))
-            .withRequestBody(WireMock.equalToJson("""{"eiers_fødselsnummer": "$eiersFødselsnummer"}""".trimIndent()))
-            .withHeader(Headers.CONTENT_TYPE, WireMock.equalTo("application/json"))
-            .willReturn(
-                WireMock.aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody("""
-                            {
-                                "content": "$content",
-                                "content_type": "application/json",
-                                "title": "Dette er en tittel",
-                                "eier": {
-                                    "eiers_fødselsnummer": "$eiersFødselsnummer"
-                                }
-                            }
-                        """.trimIndent()
-                    )
-            )
-    )
-}
-
-internal fun stubGetDokumentPdfFraK9Mellomlagring(eiersFødselsnummer: String, dokumentId: String) {
-    val content = Base64.getEncoder().encodeToString("test.pdf".fromResources().readBytes())
-    WireMock.stubFor(
-        WireMock.post(WireMock.urlPathMatching(".*$k9MellomlagringPath.*/$dokumentId"))
-            .withRequestBody(WireMock.equalToJson("""{"eiers_fødselsnummer": "$eiersFødselsnummer"}""".trimIndent()))
-            .withHeader(Headers.CONTENT_TYPE, WireMock.equalTo("application/json"))
-            .willReturn(
-                WireMock.aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody("""
-                            {
-                                "content": "$content",
-                                "content_type": "application/pdf",
-                                "title": "Dette er en tittel",
-                                "eier": {
-                                    "eiers_fødselsnummer": "$eiersFødselsnummer"
-                                }
-                            }
-                        """.trimIndent()
-                    )
-            )
-    )
-}
-
-
 internal fun WireMockServer.getDokarkivUrl() = baseUrl() + dokarkivBasePath
 internal fun WireMockServer.getK9MellomlagringUrl() = baseUrl() + k9MellomlagringPath


### PR DESCRIPTION
Fjerner gammelt felt 'dokumenter' med tilhørende logikk fordi alle prosesseringstjenestene bruker det nye feltet 'dokumentId'

Oppdaterer validering i henhold til det.

Oppdaterer pakker og refaktorerer tester.

* Closes #134 
* Closes #133 
* Closes #130
* Closes #128
* Closes  #127

Signed-off-by: Sander Opperud Odden <sander.opperud.odden@nav.no>